### PR TITLE
Improved query created files function and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,10 @@ clocal storage-stop
 clocal storage-clear
 ```
 * **List files**
-To list all files
 ```
-clocal storage-query
+clocal storage-query <query>
 ```
-To list specific folder files
-```
-clocal storage-query folder_name
-```
+Where query is `ls` or `ls <filename>` . when query is `ls` it lists all the files and if `filename` is specified , it lists only specific files.
 
 ### Azure CosmosDB (Only Windows Supported)
 

--- a/docs/azure-storage.md
+++ b/docs/azure-storage.md
@@ -55,6 +55,12 @@ clocal storage-start
 ```
 clocal storage-stop
 ```
+* **List Files**
+```
+clocal storage-query <query>
+```
+Where query is `ls` or `ls <filename>` . when query is `ls` it lists all the files and if `filename` is specified , it lists only specific files.
+
 * **Clear all files created**
 ```
 clocal storage-clear

--- a/src/services/azure-api-app-service/tests/azure-api-app-service.test.js
+++ b/src/services/azure-api-app-service/tests/azure-api-app-service.test.js
@@ -16,3 +16,13 @@ test("API app response status", async t => {
   const res = await http.getResponse(APIUrl);
   t.is(res.statusCode, 200);
 });
+
+test("Swagger UI is running", async t => {
+  const res  = await http.getResponse(APIUrl + "swagger");
+  t.is(res.info.title, "Contact List");
+});
+
+test("API app response message", async t => {
+  const res = await http.getResponse(APIUrl);
+  t.is(res, "Welcome to clocal azure api app service");
+});

--- a/src/services/azure-functions/tests/azure-function.test.js
+++ b/src/services/azure-functions/tests/azure-function.test.js
@@ -4,9 +4,16 @@ const Docker = require("dockerode");
 const tar = require("tar-fs");
 const functionUrl = "http://localhost:9574";
 
-let docker = new Docker({
-   socketPath: "/var/run/docker.sock"
-});
+let docker;
+if(process.platform != 'win32'){
+  docker = new Docker({
+    socketPath: "/var/run/docker.sock"
+  });
+} else {
+  docker = new Docker({
+    socketPath: "//./pipe/docker_engine"
+  })
+} 
 
 function timeout(ms, fn) {
   return function(t) {

--- a/src/services/azure-storage/azure-storage.js
+++ b/src/services/azure-storage/azure-storage.js
@@ -94,8 +94,9 @@ function customTerminal(container) {
       ) {
         commandHandlers[inputService](container);
       }
-      else if ( inputService.includes("clocal storage-query") ) {
-        commandHandlers['clocal storage-query'](container, inputService);
+      else if(inputService.includes("clocal storage-query")){
+        let queryString = inputService.slice(21);
+        commandHandlers['clocal storage-query'](container, queryString);
       } else {
         console.log("Invalid Command");
       }
@@ -115,8 +116,14 @@ function removeContainer() {
   });
 }
 
-function listFiles(container, fileName) {
-  fileName = fileName.split(" ")[2];
+function listFiles(container, queryString) {
+  queryString = queryString.trim();
+  let hasFilename = queryString.length > 2;
+  let fileName;
+
+  if (hasFilename){
+    fileName = queryString.slice(2);
+  }
   let options;
   if(!fileName || fileName === ""){
     options = {

--- a/src/services/azure-storage/tests/azure-storage.test.js
+++ b/src/services/azure-storage/tests/azure-storage.test.js
@@ -1,27 +1,23 @@
-import test, { beforeEach, afterEach } from "ava";
+import test from "ava";
 import http from "ava-http";
 
-const blobUrl = "http://localhost:9569";
-const queueUrl = "http://localhost:9570";
-const tableUrl = "http://localhost:9571";
-const urlPath = "/devstoreaccount1";
+const urls = {
+  blobUrl : "http://localhost:9569",
+  queueUrl : "http://localhost:9570",
+  tableUrl : "http://localhost:9571",
+  urlPath : "/devstoreaccount1",
+};
 
-test("Blob port check", t => {
-  const res = http.get(blobUrl + urlPath);
-  t.is(res.port, "9569");
-});
-
-test("Queue port check", t => {
-  const res = http.get(queueUrl);
-  t.is(res.port, "9570");
-});
-
-test("Table port check", t => {
-  const res = http.get(tableUrl);
-  t.is(res.port, "9571");
-});
+[["blob", "9569"], ["queue", "9570"], ["table", "9571"]].forEach(
+  ([nameOfType, port]) => {
+    test(`${nameOfType} port check`, t => {
+      const res = http.get(urls[nameOfType] + urls.path);
+      t.is(res.port, port);
+    });
+  }
+);
 
 test("Blob List returns true with an object", t => {
-  const res = http.get(blobUrl + "/devstoreaccount1?comp=list");
+  const res = http.get(urls.blobUrl + "/devstoreaccount1?comp=list");
   t.true(typeof res === "object");
 });


### PR DESCRIPTION
## Work Done
* Improved query created file function according to GCI Task details
 ```
clocal storage-query <query>
```
> Where query is `ls` or `ls <filename>` . when query is `ls` it lists all the files and if `filename` is specified , it lists only specific files.

* New Test Cases Were Added and Improved Old Ones
* Windows Support for `azure-function-test`
* Improved Docs and README