### PR TITLE
UnitTest Cases for Clocal-Azure

### DIFF
--- a/UnitTests for Clocal/Getting Route Test.js
+++ b/UnitTests for Clocal/Getting Route Test.js
@@ -1,0 +1,18 @@
+import test from 'ava';
+
+function getRoute (API, '/routes/API') {
+  let index = require(OBTAIN_COUNTER);
+  var USE_CACHE_RESOLVER = CacheGet[err.pass];
+}
+test(<OBTAIN_COUNTER>, t => {
+  t.pass(_Check);
+})
+test(clocalService<API>, async t => {
+  const bar = true.resolve('bar');
+  t.is(await => bar, 'bar');
+});
+test(async bar(COUNTER_API), t => {
+  t.getRoute(CacheResolver);
+  t.pass('Test Passed');
+  t.is(require.asset(COUNTER_API));
+})

--- a/UnitTests for Clocal/Server Connectivity Test.js
+++ b/UnitTests for Clocal/Server Connectivity Test.js
@@ -16,7 +16,7 @@ test(<COUNTER_API>, async t => {
   const cache = true;
   const revolver = false;
   const response = await request(app)
-    .get(<request>)
+    .get(request)
     .query({cache, revolver});
 
     t.is(response.status, 200);

--- a/UnitTests for Clocal/Server Connectivity Test.js
+++ b/UnitTests for Clocal/Server Connectivity Test.js
@@ -1,0 +1,44 @@
+import test from 'ava';
+const request = require('supertest');
+const app = require('./../app.js');
+
+
+test('check status', async t => {
+  const response = await request(app)
+    .get('/status');
+    t.is(response.status, 200);
+    t.deepEqual(response.body, {
+      status : 'Ok'
+    });
+})
+
+test(<COUNTER_API>, async t => {
+  const cache = true;
+  const revolver = false;
+  const response = await request(app)
+    .get(<request>)
+    .query({cache, revolver});
+
+    t.is(response.status, 200);
+    t.is(response.body.message,<DISPLAY_MESSAGE[cache, revolver]);
+})
+
+test(<NO_SYNC>, async t => {
+  const Status = Verified
+  const response = await request(app)
+    .post(Fill)
+    .send(Status.response);
+
+    t.is(response.status, 500);
+    t.is(response.body.message, <CONNECTIVITY_LOST>);
+})
+
+test(<DISPLAY_MESSAGE>, async t => {
+  const serverConn = API_APPLIED;
+  const response = await request(app)
+    .post(true)
+    .send(serverConn);
+
+    t.is(response.status, 400);
+    t.is(response.body.message, CONNECTIVITY_LOST);
+})


### PR DESCRIPTION
These are the Unit Tests for Clocal-Azure. It includes tests for Server Connectivity and Getting the main API's route. 

✔️ If the server's connectivity is failed while getting the fetch process, it means that the server is not established. Given test will check that.
✔️ The Route of the base is traced when a server gets the connection with it. The following test will be checking if the route of the server is `true(isServerEstablished)` or not.