### PR TITLE
Fix service exit (mySQL)

### DIFF
--- a/src/services/azure-sql-server/azure-sql-server.js
+++ b/src/services/azure-sql-server/azure-sql-server.js
@@ -113,6 +113,29 @@ function runExec(container) {
           previousKey = key;
         });
 
+        docker.getEvents({}, (err, evtSource) => {
+          evtSource.on("data", function (data) {
+            let dockerEventState = JSON.parse(String.fromCharCode.apply(String, data)); // Prevents unexpected tokens from being checked, unexpected token in JSON
+            if (dockerEventState.Actor.Attributes.execID === exec.id && dockerEventState.status === "exec_die") {
+              // As we cannot gracefully exit, we will forcefully kill and remove the container causing the terminal to update
+              console.log(data);
+              container.remove({ force: true })
+              .then(() => {
+                console.log("Successfully removed container")
+              });
+            }
+          });
+        });
+
+        // docker.getEvents({}, (err, eventStream)=>{
+        //   eventStream.on("data", function(data){
+        //     let text = JSON.parse(String.fromCharCode.apply(String, data));
+        //     if (text.status=="exec_die" && text.Actor.Attributes.execID==exec.id) {
+        //       container.remove({force:true});
+        //     }
+        //   });
+        // });
+
         container.wait(function(err, data) {
           exit(stream, isRaw);
         });


### PR DESCRIPTION
## Previous Behavior
![WindowsTerminal_Uy6AJTkmOR](https://user-images.githubusercontent.com/29003194/71326003-c1173380-24c2-11ea-86e0-f9250623b054.png)
The terminal would hang on the process, and sometimes, the Docker container would not be killed.

## New Behavior
![WindowsTerminal_DZsriISCk6](https://user-images.githubusercontent.com/29003194/71326006-d4c29a00-24c2-11ea-8e50-196327d70cbe.png)
Upon receiving the exit event, the event will be logged and the container will be forcibly removed providing a solution to the process hang.

## Related Issue
closes #60 

## Testing and Maintenance
- Tested through execution (see screenshots)
- Follows project code style
